### PR TITLE
Fix vitest setup to avoid missing expect and leftover DOM

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,9 @@
-import '@testing-library/jest-dom';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- configure jest-dom matchers with Vitest's expect
- clean up React Testing Library DOM between tests

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any. Specify a different type, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d6c9eea60832c8249378da3a43a6d